### PR TITLE
Change REPORT_OUTPUT naming to prevent overwrite of batch output

### DIFF
--- a/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
+++ b/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
@@ -32,7 +32,9 @@ void replay_production_coin_NPS_HMS(int RunNumber=0, int MaxEvent=0, int FirstEv
   if (MaxEvent == 50000 && FirstEvent == 1){
     ROOTFileNamePattern = "ROOTfiles/COIN/50k/nps_hms_coin_%d_%d_%d.root";
   }
-  else{
+  else if (MaxEvent == -1 && (FirstSegment - MaxSegment) == 0) {
+    ROOTFileNamePattern = "ROOTfiles/COIN/PRODUCTION/nps_hms_coin_%d_%d_%d_%d.root";
+  }  else{
     ROOTFileNamePattern = "ROOTfiles/COIN/PRODUCTION/nps_hms_coin_%d_%d_%d.root";
   }
   
@@ -234,7 +236,12 @@ void replay_production_coin_NPS_HMS(int RunNumber=0, int MaxEvent=0, int FirstEv
   run->Print();
   
   // Define the analysis parameters
-  TString ROOTFileName = Form(ROOTFileNamePattern, RunNumber, FirstEvent, MaxEvent);
+  TString ROOTFileName;
+  if(MaxEvent == -1 && (FirstSegment - MaxSegment) == 0) {
+    ROOTFileName = Form(ROOTFileNamePattern, RunNumber, FirstSegment, FirstEvent, MaxEvent);
+  } else {
+     ROOTFileName = Form(ROOTFileNamePattern, RunNumber, FirstEvent, MaxEvent);
+  }
 
   // Define the analysis parameters
   analyzer->SetEvent(event);

--- a/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
+++ b/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
@@ -266,7 +266,12 @@ void replay_production_coin_NPS_HMS(int RunNumber=0, int MaxEvent=0, int FirstEv
   // start the actual analysis
   analyzer->Process(run);     
   // Create report file from template.
-  analyzer->PrintReport("TEMPLATES/NPS/NPS_coin.template",
+  if(MaxEvent == -1 && (FirstSegment - MaxSegment) == 0) {
+    analyzer->PrintReport("TEMPLATES/NPS/NPS_coin.template",
+			  Form("REPORT_OUTPUT/COIN/coin_NPS_HMS_report_%d_%d_%d_%d.report",
+			  RunNumber, FirstSegment, FirstEvent, MaxEvent)); //FIXME:CHANGE
+  } else {
+    analyzer->PrintReport("TEMPLATES/NPS/NPS_coin.template",
 			Form("REPORT_OUTPUT/COIN/coin_NPS_HMS_report_%d_%d.report", RunNumber, MaxEvent)); //FIXME:CHANGE
-  
+  }
 }


### PR DESCRIPTION
Fix REPORT_OUTPUT file naming to prevent overwriting similarly named files in batch submission.  