### PR TITLE
Use container with sbatch

### DIFF
--- a/jobs/run_apptainer.sh
+++ b/jobs/run_apptainer.sh
@@ -8,45 +8,46 @@ runNum=$1
 nEvent=$2
 
 # Modify as you need
-#-----------------------------------------
-SCRDIR="/work/hallc/nps/panta/nps_replay"  # source dir
-BASEDIR="/volatile/hallc/nps/panta"        # log output dir
-script="SCRIPTS/${SPEC}/eel108_replay.C"   # script to run
-APPTAINER_IMAGE="/xxx/xxxx/xx.sif"         # apptainer image location
+#--------------------------------------------------
+SCRDIR="/volatile/hallc/nps/panta/nps_replay"         # source dir
+BASEDIR="/volatile/hallc/nps/panta/nps_replay"        # log output dir
+SCRIPT="SCRIPTS/${SPEC}/eel108_replay.C"              # script to run
+APPTAINER_IMAGE="/volatile/hallc/nps/panta/nps.sif"   # apptainer image location
+RAWDIR="/cache/hallc/c-nps/raw/"
+#---------------------------------------------------
 
-#-----------------------------------------
 
 cd $SCRDIR
 
+# Check if SCRDIR and BASEDIR are the same
+if [ "$SCRDIR" == "$BASEDIR" ]; then
+    # If same, only create directories in SCRDIR
+    OUTDIR="${SCRDIR}/ROOTfiles"
+    REPORTDIR="${SCRDIR}/REPORT_OUTPUT"
 
-# ROOT output directory
-OUTDIR=${BASEDIR}/ROOTfiles
-if [ ! -d ${OUTDIR} ]
-then
-    echo "ROOT output directory does not exist.. make new one"
-    mkdir -p ${OUTDIR}
+    # Create directories if they don't exist
+    if [ ! -d "$OUTDIR" ]; then
+        echo "OUTDIR does not exist.. creating"
+        mkdir -p "$OUTDIR"
+    fi
+
+    if [ ! -d "$REPORTDIR" ]; then
+        echo "REPORTDIR does not exist.. creating"
+        mkdir -p "$REPORTDIR"
+    fi
+else
+    # SCR and BASE DIR are different need to do symlink
+    # need to consult with nps_replay user/developer
+    # ADD ME
 fi
 
-# set symbolic link in the current working dir, if not done already
-if [ ! -d ROOTfiles ] 
-then
-    ln -sf $OUTDIR ROOTfiles
+# Q. Is the following the way to handle input raw data?
+if [ ! -L "raw" ]; then
+    ln -sf "$RAWDIR" "raw"
 fi
-    
-# REPORT OUTPUT directory
-REPORTDIR=${BASEDIR}/REPORT_OUTPUT
-if [ ! -d ${REPORTDIR} ]
-then
-    echo "ROOT output directory does not exist.. make new one"
+if [ ! -L "cache" ]; then
+    ln -sf "$RAWDIR" "cache"
 fi
-
-# set symbolic link in the current working dir, if not done already
-if [ ! -d REPORT_OUTPUT ] 
-then
-    mkdir -p ${REPORTDIR}
-    ln -sf $REPORTDIR REPORT_OUTPUT
-fi
-
 # Check if apptainer is available
 if command -v apptainer > /dev/null 2>&1; then
     echo "apptainer is already available."
@@ -62,5 +63,5 @@ echo "NPS SINGLE REPLAY for ${runNum}. NEvent=${nEvent} using NPSlib container=$
 echo "----------------------------------------------------------------------------------------------"
 echo 
 
-runStr="apptainer exec --bind ${SCRDIR} --bind ${BASEDIR} --bind ${script} ${APPTAINER_IMAGE} bash -c \"hcana -q SCRIPTS/NPS/eel108_replay.C\(${runNum},${nEvent}\)\""
+runStr="apptainer exec --bind ${SCRDIR} --bind ${BASEDIR} --bind ${SCRIPT} ${APPTAINER_IMAGE} bash -c \"hcana -q ${SCRIPT}\(${runNum},${nEvent}\)\""
 eval ${runStr}

--- a/jobs/run_apptainer.sh
+++ b/jobs/run_apptainer.sh
@@ -18,15 +18,6 @@ APPTAINER_IMAGE="/xxx/xxxx/xx.sif"         # apptainer image location
 
 cd $SCRDIR
 
-# check if env vars are set properly
-# if not run the setup script
-if [ -z "$HCANA" ]
-then
-    echo "HCANA not set.."
-    echo "run the setup script.."
-    setup_farm.sh
-fi
-
 
 # ROOT output directory
 OUTDIR=${BASEDIR}/ROOTfiles

--- a/jobs/run_apptainer.sh
+++ b/jobs/run_apptainer.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+spec="nps"
+SPEC="NPS"
+
+# Two input args
+runNum=$1
+nEvent=$2
+
+# Modify as you need
+#-----------------------------------------
+SCRDIR="/work/hallc/nps/panta/nps_replay"  # source dir
+BASEDIR="/volatile/hallc/nps/panta"        # log output dir
+script="SCRIPTS/${SPEC}/eel108_replay.C"   # script to run
+APPTAINER_IMAGE="/xxx/xxxx/xx.sif"         # apptainer image location
+
+#-----------------------------------------
+
+cd $SCRDIR
+
+# check if env vars are set properly
+# if not run the setup script
+if [ -z "$HCANA" ]
+then
+    echo "HCANA not set.."
+    echo "run the setup script.."
+    setup_farm.sh
+fi
+
+
+# ROOT output directory
+OUTDIR=${BASEDIR}/ROOTfiles
+if [ ! -d ${OUTDIR} ]
+then
+    echo "ROOT output directory does not exist.. make new one"
+    mkdir -p ${OUTDIR}
+fi
+
+# set symbolic link in the current working dir, if not done already
+if [ ! -d ROOTfiles ] 
+then
+    ln -sf $OUTDIR ROOTfiles
+fi
+    
+# REPORT OUTPUT directory
+REPORTDIR=${BASEDIR}/REPORT_OUTPUT
+if [ ! -d ${REPORTDIR} ]
+then
+    echo "ROOT output directory does not exist.. make new one"
+fi
+
+# set symbolic link in the current working dir, if not done already
+if [ ! -d REPORT_OUTPUT ] 
+then
+    mkdir -p ${REPORTDIR}
+    ln -sf $REPORTDIR REPORT_OUTPUT
+fi
+
+# Check if apptainer is available
+if command -v apptainer > /dev/null 2>&1; then
+    echo "apptainer is already available."
+else
+    # Load apptainer if not available
+    echo "Loading apptainer..."
+    eval module load apptainer
+fi
+
+echo 
+echo "---------------------------------------------------------------------------------------------"
+echo "NPS SINGLE REPLAY for ${runNum}. NEvent=${nEvent} using NPSlib container=${APPTAINER_IMAGE}"
+echo "----------------------------------------------------------------------------------------------"
+echo 
+
+runStr="apptainer exec --bind ${SCRDIR} --bind ${BASEDIR} --bind ${script} ${APPTAINER_IMAGE} bash -c \"hcana -q SCRIPTS/NPS/eel108_replay.C\(${runNum},${nEvent}\)\""
+eval ${runStr}

--- a/jobs/submit.sh
+++ b/jobs/submit.sh
@@ -9,7 +9,7 @@ jobname=$3
 #-----------------------------------------
 jobdir=`pwd`
 script="${jobdir}/run.sh"
-outdir="/volatile/hallc/nps/sanghwa/log"
+outdir="/volatile/hallc/nps/panta/log"
 #-----------------------------------------
 
 if [ ! -d ${outdir} ]

--- a/jobs/submit.sh
+++ b/jobs/submit.sh
@@ -5,6 +5,7 @@ nevt=$2
 jobname=$3
 
 # MODIFY THIS PART AS YOU NEED
+# to use the apptainer image replace run.sh in script path to run_apptainer.sh
 #-----------------------------------------
 jobdir=`pwd`
 script="${jobdir}/run.sh"

--- a/jobs/submit.sh
+++ b/jobs/submit.sh
@@ -9,7 +9,7 @@ jobname=$3
 #-----------------------------------------
 jobdir=`pwd`
 script="${jobdir}/run.sh"
-outdir="/volatile/hallc/nps/panta/log"
+outdir="/volatile/hallc/nps/sanghwa/log"
 #-----------------------------------------
 
 if [ ! -d ${outdir} ]

--- a/jobs/submit_jobs.py
+++ b/jobs/submit_jobs.py
@@ -7,7 +7,11 @@ def get_usage():
     return """
          To see options:
          > submit_jobs.py --help
-
+         
+         To use apptainer image change the line:
+         script = sourceDir+"/jobs/run.sh"
+         to
+         script = sourceDir+"/jobs/run_apptainer.sh"
          Examples:
          > python submit_jobs.py --runs=<run numbers, range> --nevt=<number of events to replay> --email=<your email address, optional>
          > python submit_jobs.py --runs=123,135-144,119 --nevt=1000


### PR DESCRIPTION
An example for using apptainer image with nps_replay 
(More on this after @mrcmor100  report, like multi image run in single node and so on)

changes/addition.

1. Added new run_apptainer.sh script. 
    -> Few questions in the comments of the script. @MarkKJones @sanghwapark may have answer. 
    -> APPTAINER_IMAGE is the location of image. May be we need add a instruction on building image or link to container documentation.
    
2. Added what needs be changed when using sbatch for both single job or multi jobs.
   -> Tested a single job REPORT_OUTPUT and ROOTfiles folder in SCRDIR . 
   -> Okay.


My thought:
It will be good idea to add a procedure to run swif job with nps_replay and container.
But  I am not familiar with it. If someone can give me example of it. I can run a test using apptainer.
  