### PR TITLE
#36 add env var option

### DIFF
--- a/SCRIPTS/NPS/eel108_replay.C
+++ b/SCRIPTS/NPS/eel108_replay.C
@@ -23,7 +23,7 @@ void eel108_replay(Int_t RunNumber=0, Int_t MaxEvent=0)
   TString datadir = gSystem->Getenv("DATA_DIR");
   vector<TString> pathList;
   if ( !datadir.IsNull() ) {
-    pathlist.push_back(datadir.Data());
+    pathList.push_back(datadir.Data());
   }
   else {
     pathList.push_back(".");
@@ -33,7 +33,7 @@ void eel108_replay(Int_t RunNumber=0, Int_t MaxEvent=0)
     pathList.push_back("/net/cdaq/cdaql1data/coda/data/raw");
   }
 
-  for( const auto& path: pathlist ) {
+  for( const auto& path: pathList ) {
     cout << "search paths = " << path << endl;
   }
   

--- a/SCRIPTS/NPS/eel108_replay.C
+++ b/SCRIPTS/NPS/eel108_replay.C
@@ -20,13 +20,32 @@ void eel108_replay(Int_t RunNumber=0, Int_t MaxEvent=0)
   // const char* RunFileNamePattern="NPS_3crate_%d.evio.0";
   //const char* RunFileNamePattern="nps_coin_%d.dat.0";
   const char* RunFileNamePattern="nps_%d.dat.0";
+  TString datadir = gSystem->Getenv("DATA_DIR");
   vector<TString> pathList;
-  pathList.push_back(".");
-  pathList.push_back("./raw");
-  pathList.push_back("./raw/../raw.copiedtotape");
-  pathList.push_back("./cache");
-  pathList.push_back("/net/cdaq/cdaql1data/coda/data/raw");
-  const char* ROOTFileNamePattern = "ROOTfiles/nps_%d.root";
+  if ( !datadir.IsNull() ) {
+    pathlist.push_back(datadir.Data());
+  }
+  else {
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./raw/../raw.copiedtotape");
+    pathList.push_back("./cache");
+    pathList.push_back("/net/cdaq/cdaql1data/coda/data/raw");
+  }
+
+  for( const auto& path: pathlist ) {
+    cout << "search paths = " << path << endl;
+  }
+  
+  TString outdir = gSystem->Getenv("OUT_DIR");
+  const char* ROOTFileNamePattern;
+  if ( !datadir.IsNull() ) {
+    ROOTFileNamePattern = Form("%s/nps_%%d.root", outdir.Data());
+  }
+  else {
+    ROOTFileNamePattern = "ROOTfiles/nps_%d.root" ;
+  }
+  
   
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber); 
@@ -90,7 +109,12 @@ void eel108_replay(Int_t RunNumber=0, Int_t MaxEvent=0)
   
   analyzer->Process(run);     // start the actual analysis
   // Create report file from template.
-  analyzer->PrintReport("TEMPLATES/NPS/NPS.template",
+  TString logdir = gSystem->Getenv("LOG_DIR");
+  if( !logdir.IsNull() ) {
+    analyzer->PrintReport("TEMPLATES/NPS/NPS.template", Form("%s/eel108_report_%d_%d.report", logdir.Data(), RunNumber, MaxEvent));
+  }
+  else{
+    analyzer->PrintReport("TEMPLATES/NPS/NPS.template",
 			Form("REPORT_OUTPUT/NPS/eel108/eel108_report_%d_%d.report", RunNumber, MaxEvent));
-  
+  }
 }


### PR DESCRIPTION
Closes #36 .
Added ENV variables:
1. DATA_DIR 
    This is for input file directory specification. like `DATA_DIR=/cache/hallc/c-nps/raw`
2. LOG_DIR
    This is for report of the output. like: `LOG_DIR=/volatile/hallc/nps/panta/nps_log`
3. OUT_DIR
    This is for output rootfiles. like: `OUT_DIR=/volatile/hallc/nps/panta/nps_root`
    
If env variable is set it uses it .
else it fall back to current mechanism.

Tested:
1. Setting env var.
2. Using current default behavior.
Both ok.
