### PR TITLE
changed signs of fr_ya, fr_yb to +

### DIFF
--- a/PARAM/GEN/gbeam_fa22.param
+++ b/PARAM/GEN/gbeam_fa22.param
@@ -82,8 +82,8 @@ gfryb_adc_zero_offset = 54800
 ;
 gfrxa_adcpercm = -(63427-44954)/.2
 gfrxb_adcpercm = -(63841-44824)/.2
-gfrya_adcpercm = -(65450-44885)/.2
-gfryb_adcpercm = -(64417-45240)/.2
+gfrya_adcpercm = (65450-44885)/.2
+gfryb_adcpercm = (64417-45240)/.2
 
  
  

--- a/PARAM/GEN/gbeam_fa23.param
+++ b/PARAM/GEN/gbeam_fa23.param
@@ -50,8 +50,8 @@ gfryb_adc_zero_offset = 54800
 ;
 gfrxa_adcpercm = -(63427-44954)/.2
 gfrxb_adcpercm = -(63841-44824)/.2
-gfrya_adcpercm = -(65450-44885)/.2
-gfryb_adcpercm = -(64417-45240)/.2
+gfrya_adcpercm = (65450-44885)/.2
+gfryb_adcpercm = (64417-45240)/.2
 
  
  


### PR DESCRIPTION
This change fixes the raster issue made apparent by plotting kinW vs fr_ya on LH2 run #1251
See logbook entry: https://logbooks.jlab.org/entry/4228917