### PR TITLE
Add NPS configuration parameters to report output

### DIFF
--- a/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
+++ b/SCRIPTS/NPS/replay_production_coin_NPS_HMS.C
@@ -200,6 +200,11 @@ void replay_production_coin_NPS_HMS(int RunNumber=0, int MaxEvent=0, int FirstEv
   THcConfigEvtHandler* ev125 = new THcConfigEvtHandler("HC", "Config Event type 125");
   gHaEvtHandlers->Add(ev125);
 
+  THcNPSConfigEvtHandler* npsconfig = new THcNPSConfigEvtHandler("npsconfig", "NPS configuration event handler");
+  // Four parameters are added by default (see THcNPSConfigEvtHandler::Init) 
+  // To add more parameters, one can use: npsconfig->AddParameter("parameter name", "key name")
+  // e.g: npsconfig->AddParameter("fadc250_nsa", "FADC250_NSA");
+  gHaEvtHandlers->Add(npsconfig);
 
   // Set up the analyzer - we use the standard one,
   // but this could be an experiment-specific one as well.

--- a/SCRIPTS/NPS/replay_production_skim_NPS_HMS.C
+++ b/SCRIPTS/NPS/replay_production_skim_NPS_HMS.C
@@ -195,6 +195,11 @@ void replay_production_skim_NPS_HMS(int RunNumber=0, int MaxEvent=0, int FirstEv
   THcConfigEvtHandler* ev125 = new THcConfigEvtHandler("HC", "Config Event type 125");
   gHaEvtHandlers->Add(ev125);
 
+  THcNPSConfigEvtHandler* npsconfig = new THcNPSConfigEvtHandler("npsconfig", "NPS configuration event handler");
+  // Four parameters are added by default (see THcNPSConfigEvtHandler::Init) 
+  // To add more parameters, one can use: npsconfig->AddParameter("parameter name", "key name")
+  // e.g: npsconfig->AddParameter("fadc250_nsa", "FADC250_NSA");
+  gHaEvtHandlers->Add(npsconfig);
 
   // Set up the analyzer - we use the standard one,
   // but this could be an experiment-specific one as well.

--- a/TEMPLATES/NPS/NPS_coin.template
+++ b/TEMPLATES/NPS/NPS_coin.template
@@ -60,6 +60,15 @@ Ps4_factor = {ghconfig_ti_ps_factors[3]}
 Ps5_factor = {ghconfig_ti_ps_factors[4]}
 Ps6_factor = {ghconfig_ti_ps_factors[5]}
 
+********************
+* NPS Configuration
+********************
+
+FADC250 Sparsification		   : {gnpsconfig_fadc250_sparsification}
+VTP Cluster Trigger Threshold      : {gnpsconfig_vtp_clus_trig_thr}
+VTP Cluster Readout Threshold      : {gnpsconfig_vtp_clus_ro_thr}
+VTP Cluster Pair Trigger Threshold : {gnpsconfig_vtp_pair_trig_thr}
+
 ***********
 * Triggers
 ***********


### PR DESCRIPTION
Updated NPS_coin.template and replay scripts to include NPS configuration parameters in the report output as Peter requested.