### PR TITLE
Updated BPM z positions to Fall 2023 survey data

### DIFF
--- a/PARAM/GEN/gbeam_fa23.param
+++ b/PARAM/GEN/gbeam_fa23.param
@@ -25,9 +25,9 @@
 ;
 
 ;positions of BPMs relative to target (from target_bpm.py script)
-gbpma_zpos = 320.17 ; cm
-gbpmb_zpos = 224.81 ; cm
-gbpmc_zpos = 129.38 ; cm
+gbpma_zpos = 320.22 ; cm
+gbpmb_zpos = 224.62 ; cm
+gbpmc_zpos = 124.36 ; cm
 
 
 ;             Fast Raster calibration constants

--- a/PARAM/GEN/gbeam_sp24.param
+++ b/PARAM/GEN/gbeam_sp24.param
@@ -29,9 +29,9 @@
 ;
 
 ;positions of BPMs relative to target (from target_bpm.py script)
-gbpma_zpos = 320.17 ; cm
-gbpmb_zpos = 224.81 ; cm
-gbpmc_zpos = 129.38 ; cm
+gbpma_zpos = 320.22 ; cm
+gbpmb_zpos = 224.62 ; cm
+gbpmc_zpos = 124.36 ; cm
 
 
 ;             Fast Raster calibration constants


### PR DESCRIPTION
Updated z positions for Hall C BPMS A, B, C from Sept 2023 survey results: 
(https://www.jlab.org/accel/survalign/documents%20(k)/dthallc/C2084.pdf)

Units in cm

No changes to the calibration in this pull request